### PR TITLE
Multiline help text with indentation

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,4 @@
+* 3.4.* - Indent multiline command descriptions
 * 3.3.* - Fixed scanf parser.
 * 3.2.* - Fixed scanf parser.
 * 3.1.* - Improve comments. Some refactoring.

--- a/src/FSharp.CommandLine/generators.fs
+++ b/src/FSharp.CommandLine/generators.fs
@@ -24,13 +24,21 @@ module Generators =
       let indent = "                                 "
       let indentLen = String.length indent
       let aLen = String.length a
-      if aLen > indentLen then
+      let bLines = String.replace "\r" "" b |> String.split "\n" |> List.ofArray
+      if List.isEmpty bLines then
         seq {
           yield sprintf "%s" a
-          yield sprintf "%s %s" indent b
+        }
+      elif aLen > indentLen then
+        seq {
+          yield sprintf "%s" a
+          yield! (bLines |> List.map (sprintf "%s %s" indent))
         }
       else
-        seq { yield sprintf "%s %s" a (String.replicate (indentLen - aLen) " " |> sprintf "%s%s" <| b) }
+        seq {
+          yield sprintf "%s %s" a (String.replicate (indentLen - aLen) " " |> sprintf "%s%s" <| bLines.Head)
+          yield! (bLines.Tail |> List.map (sprintf "%s %s" indent))
+        }
 
     let private genParamNames pns subs options = 
       match pns with

--- a/src/common/Version.fs
+++ b/src/common/Version.fs
@@ -2,10 +2,10 @@
 namespace System
 open System.Reflection
 
-[<assembly: AssemblyVersionAttribute("3.4.4032.35410")>]
-[<assembly: AssemblyFileVersionAttribute("3.4.4032.35410")>]
+[<assembly: AssemblyVersionAttribute("3.3.3805.29705")>]
+[<assembly: AssemblyFileVersionAttribute("3.3.3805.29705")>]
 do ()
 
 module internal AssemblyVersionInformation =
-    let [<Literal>] AssemblyVersion = "3.4.4032.35410"
-    let [<Literal>] AssemblyFileVersion = "3.4.4032.35410"
+    let [<Literal>] AssemblyVersion = "3.3.3805.29705"
+    let [<Literal>] AssemblyFileVersion = "3.3.3805.29705"

--- a/src/common/Version.fs
+++ b/src/common/Version.fs
@@ -2,10 +2,10 @@
 namespace System
 open System.Reflection
 
-[<assembly: AssemblyVersionAttribute("3.3.3805.29705")>]
-[<assembly: AssemblyFileVersionAttribute("3.3.3805.29705")>]
+[<assembly: AssemblyVersionAttribute("3.4.4032.35410")>]
+[<assembly: AssemblyFileVersionAttribute("3.4.4032.35410")>]
 do ()
 
 module internal AssemblyVersionInformation =
-    let [<Literal>] AssemblyVersion = "3.3.3805.29705"
-    let [<Literal>] AssemblyFileVersion = "3.3.3805.29705"
+    let [<Literal>] AssemblyVersion = "3.4.4032.35410"
+    let [<Literal>] AssemblyFileVersion = "3.4.4032.35410"


### PR DESCRIPTION
## Sample

I altered the `test.fsx` file to try this out.

```fsx
let fileOption =
  commandOption {
    names ["f"; "file"]
    description "Name of a file to use\n\
                 Default index: 0\n\
                 Look multiple lines!\n\
                 Neat!"
    takes (format("%s:%i").withNames ["filename"; "index"])
    takes (format("%s").map (fun filename -> (filename, 0)))
    suggests (fun _ -> [CommandSuggestion.Files None])
  }
```

I did not push those changes ^ they were just for manual testing. Would you prefer some code added for that?

## Previous output

```
$ dotnet fsi test.fsx
test> help
num: 0
error: showing help.

usage: main [options] <command>

The main command.

commands:
  echo [options]                    Echo the input.

options:
  -n, --number=<num>                integer number.
  -v, --verbosity={q(uiet)?$|n(ormal)?$|f(ull)?$|c{ustom:<level>|:<level>}}
                                    Display this amount of information in the log.
  -f, --file=<filename>[:<index>]   Name of a file to use
Default index: 0
Look multiple lines!
Neat!
test>
```

## New output

```
$ dotnet fsi test.fsx
test> help
num: 0
error: showing help.

usage: main [options] <command>

The main command.

commands:
  echo [options]                    Echo the input.

options:
  -n, --number=<num>                integer number.
  -v, --verbosity={q(uiet)?$|n(ormal)?$|f(ull)?$|c{ustom:<level>|:<level>}}
                                    Display this amount of information in the log.
  -f, --file=<filename>[:<index>]   Name of a file to use
                                    Default index: 0
                                    Look multiple lines!
                                    Neat!
test>
```

